### PR TITLE
+stryker

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "dotnet-ef"
       ]
+    },
+    "dotnet-stryker": {
+      "version": "4.0.5",
+      "commands": [
+        "dotnet-stryker"
+      ]
     }
   }
 }


### PR DESCRIPTION
- [ ] CI
- [ ] benefits compared to code coverage

One way could be to have a GitHub Action that does: `dotnet stryker --break-at 80`